### PR TITLE
Pass plainText to transformPastedText and clipboardTextParser props

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -40,9 +40,9 @@ export function parseFromClipboard(view, text, html, plainText, $context) {
   if (!html && !text) return null
   let asText = text && (plainText || inCode || !html)
   if (asText) {
-    view.someProp("transformPastedText", f => { text = f(text) })
+    view.someProp("transformPastedText", f => { text = f(text, plainText) })
     if (inCode) return new Slice(Fragment.from(view.state.schema.text(text)), 0, 0)
-    let parsed = view.someProp("clipboardTextParser", f => f(text, $context))
+    let parsed = view.someProp("clipboardTextParser", f => f(text, $context, plainText))
     if (parsed) {
       slice = parsed
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -516,10 +516,10 @@ function needChromeSelectionReset(context, root) {
 //   the clipboard. When not given, the value of the
 //   [`domParser`](#view.EditorProps.domParser) prop is used.
 //
-//   transformPastedText:: ?(text: string) → string
+//   transformPastedText:: ?(text: string, plainText: bool) → string
 //   Transform pasted plain text.
 //
-//   clipboardTextParser:: ?(text: string, $context: ResolvedPos) → Slice
+//   clipboardTextParser:: ?(text: string, $context: ResolvedPos, plainText: bool) → Slice
 //   A function to parse text from the clipboard into a document
 //   slice. Called after
 //   [`transformPastedText`](#view.EditorProps.transformPastedText).


### PR DESCRIPTION
# Problem


I'd like to use `clipboardTextParser` prop to convert pasted text.
Specifically, I tried to use it to convert pasted markdown text to ProseMirror's node. For example, pasted `> foo` is converted to `blockquote` node.

It almost works well, but I have a problem related to `plainText`.

I expect to disable the converting feature when a user pastes text with `Control + Shift + v`, but `clipboardTextParser` isn't aware of `plainText` or not. So actually it always converts the pasted text to ProseMirror's node.




# Solution


Pass `plainText` to `clipboardTextParser`.
By this change, I can disable the converting feature with Shift key by the following code.


```javascript
new Plugin({
  props: {
    clipboardTextParser(text, $context, plainText) {
      if (plainText) {
        return null;
      }

      return convert(text, $context);
    },
  },
});
```


And I think `transformPastedText` prop has the same problem, so I also made the same change to the prop.


